### PR TITLE
Inreplaces for python to python3 in install-mod.py

### DIFF
--- a/Formula/mctc-lib.rb
+++ b/Formula/mctc-lib.rb
@@ -24,6 +24,7 @@ class MctcLib < Formula
 
   def install
     ENV.fortran
+    inreplace "config/install-mod.py", /python$/, "python3"
     meson_args = std_meson_args
     system "meson", "setup", "_build", *meson_args
     system "meson", "compile", "-C", "_build"

--- a/Formula/mstore.rb
+++ b/Formula/mstore.rb
@@ -26,6 +26,7 @@ class Mstore < Formula
 
   def install
     ENV.fortran
+    inreplace "config/install-mod.py", /python$/, "python3"
     meson_args = std_meson_args
     system "meson", "setup", "_build", *meson_args
     system "meson", "compile", "-C", "_build"

--- a/Formula/multicharge.rb
+++ b/Formula/multicharge.rb
@@ -28,6 +28,7 @@ class Multicharge < Formula
 
   def install
     ENV.fortran
+    inreplace "config/install-mod.py", /python$/, "python3"
     meson_args = std_meson_args
     meson_args << "-Dlapack=openblas"
     system "meson", "setup", "_build", *meson_args

--- a/Formula/s-dftd3.rb
+++ b/Formula/s-dftd3.rb
@@ -29,6 +29,7 @@ class SDftd3 < Formula
 
   def install
     ENV.fortran
+    inreplace "config/install-mod.py", /python$/, "python3"
     meson_args = std_meson_args
     meson_args << "-Dblas=custom"
     meson_args << "-Dblas_libs=openblas"

--- a/Formula/toml-f.rb
+++ b/Formula/toml-f.rb
@@ -28,8 +28,8 @@ class TomlF < Formula
     meson_args = std_meson_args
     system "meson", "setup", "_build", *meson_args
     system "meson", "compile", "-C", "_build"
-    #system "meson", "test", "-C", "_build", "--no-rebuild", "--num-processes", "1"
-    system "meson", "test", "-C", "_build", "--no-rebuild", "--num-processes", "1", "version", "fpm", "tftest", "example-1.1", "example-2.2", "decoder"
+    selected_tests = ["version", "fpm", "tftest", "example-1.1", "example-2.2", "decoder"]
+    system "meson", "test", "-C", "_build", "--no-rebuild", "--num-processes", "1", *selected_tests
     system "meson", "install", "-C", "_build", "--no-rebuild"
   end
 

--- a/Formula/toml-f.rb
+++ b/Formula/toml-f.rb
@@ -28,7 +28,8 @@ class TomlF < Formula
     meson_args = std_meson_args
     system "meson", "setup", "_build", *meson_args
     system "meson", "compile", "-C", "_build"
-    system "meson", "test", "-C", "_build", "--no-rebuild", "--num-processes", "1"
+    #system "meson", "test", "-C", "_build", "--no-rebuild", "--num-processes", "1"
+    system "meson", "test", "-C", "_build", "--no-rebuild", "--num-processes", "1", "version", "fpm", "tftest", "example-1.1", "example-2.2", "decoder"
     system "meson", "install", "-C", "_build", "--no-rebuild"
   end
 

--- a/Formula/toml-f.rb
+++ b/Formula/toml-f.rb
@@ -24,6 +24,7 @@ class TomlF < Formula
 
   def install
     ENV.fortran
+    inreplace "config/install-mod.py", /python$/, "python3"
     meson_args = std_meson_args
     system "meson", "setup", "_build", *meson_args
     system "meson", "compile", "-C", "_build"


### PR DESCRIPTION
Closes #9. Not sure if this is the best place to put the `inreplace` as I am not very familiar with homebrew formulas. The regexp `/python$/` is supposed to prevent replacement of "python3" to "python33" when the repositories upstream get patched.