### PR TITLE
Re-upload `mctc-lib` artifacts so that all platforms are supported

### DIFF
--- a/Formula/mctc-lib.rb
+++ b/Formula/mctc-lib.rb
@@ -4,6 +4,7 @@ class MctcLib < Formula
   url "https://github.com/grimme-lab/mctc-lib/archive/refs/tags/v0.3.2.tar.gz"
   sha256 "b18b06f80e6274b353dd091c12b3a83217033ce0bd80471b54cf486cc60c0251"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     root_url "https://github.com/grimme-lab/homebrew-qc/releases/download/mctc-lib-0.3.2"


### PR DESCRIPTION
- re-upload artifacts so that all platforms are supported